### PR TITLE
Improve performance of project library export for large projects

### DIFF
--- a/statix.runtime/trans/statix/runtime/menus.str
+++ b/statix.runtime/trans/statix/runtime/menus.str
@@ -24,5 +24,5 @@ rules
     with
       filename := "project.stxlib"
     ; sg := <stx--get-scopegraph;strip-annos> a*
-    ; s* := <collect-all(stx--is-scope);make-set> sg
+    ; s* := <collect-all(stx--is-scope, TupleToList; concat); imset-from-list; imset-to-list> sg
     ; result := Library([], s*, sg)


### PR DESCRIPTION
Performance of default `collect-all` and `make-set` is too bad to be used practically for larger projects.
Recently I tried to do an StxLib export of a standard library project, which contained ~180 files, in total consisting of about 26k SLOC.
My Statix specification is not too small either, but I would not consider either 'large'.

After an hour I killed the project library exporting and started debugging.
This led me to discovering that `collect-all` and `make-set` do not appear to scale well.
Both use `union` internally which appears to be the main underlying cause.

That is why I pass a different union strategy to `collect-all`, overriding the default.
This is a dummy union implementation which merely concats the two lists.
Concatenating lists is still not _too_ efficient, major optimizations could be done if StrategoArrayLists were to be concatenated as a view (in this particular case, might be suboptimal otherwise).

Anyways, this means that the result of `collect-all` is not distinct anymore, so I still pass it through some alternative set creation strategies.
These replace `make-set` (which actually wouldn't have been necessary before, because `collect-all` produces a distinct result).
Uses strategies from the relatively new immutable collections API [from the standard library](https://github.com/metaborg/strategoxt/blob/master/strategoxt/stratego-libraries/strc/lib/stratego/strc/immutable/set.str).

Exporting a StxLib from my project now takes about 35 seconds (instead of 1h+).
As far as I am aware, the effective output is the same.